### PR TITLE
Fixed Channel Frequencies

### DIFF
--- a/gdat.py
+++ b/gdat.py
@@ -76,14 +76,13 @@ def decode_packets(bytes, channels, parameters):
 # value = encoded_value * 10^-shift * scalar / divisor
 # encoded_value = value / 10^-shift / scalar * divisor
 # to make the most of a s16: abs_max = (2^15 - 1) * 10^-shift * scalar / divisor
-def get_scalars(id, v_min, v_max):
+def get_scalars(v_min, v_max):
     abs_max = max(abs(v_min), abs(v_max))
 
     exp = 0
     scale = abs_max
     scf = 0
     shift = 0
-    offset = 0
     done = False
 
     if v_max - v_min <= 0.001:
@@ -106,40 +105,40 @@ def get_scalars(id, v_min, v_max):
         exp += 1
 
     if not done:
-        print(f'failed to find scalars for ch={id} min={v_min} max={v_max}')
+        raise Exception('encoding failed')
     
     scalar, divisor = Fraction(scf).limit_denominator(2047).as_integer_ratio()
     if scalar > 2047:
-        scalar = 0
-        divisor = 0
-        shift = 0
+        raise Exception('encoding failed')
     
-    return (shift, scalar, divisor, scf)
+    return (shift, scalar, divisor)
 
 def parse(bytes, parameters):
     channels = {
         id: {
+            # raw data
             'id': id,
             'name': param['name'],
             'unit': param['unit'],
-            'sample_count': 0,
+            'n_points': 0,              # num raw datapoints
+            't_min': 0,                 # min datapoint timestamp
+            't_max': 0,                 # max datapoint timestamp
+            'v_min': 0,                 # min datapoint value
+            'v_max': 0,                 # max datapoint value
+            'points': [],
+            # interpolated data
             'delta_ms': 0,
             'frequency_hz': 0,
-            't_min': 0,
-            't_max': 0,
-            'v_min': 0,
-            'v_max': 0,
-            # scalars to encode in s16
+            'sample_count': 0,
+            't_int': [],                # evenly spaced timestamps
+            'v_int': [],                # interpolated values
+            # s32 encoded data (on t_int time axis)
+            # encoded_value = value / 10^-shift / scalar * divisor
+            'v_enc': [],
             'shift': 0,
-            'scalar': 1,
-            'divisor': 1,
+            'scalar': 0,
+            'divisor': 0,
             'offset': 0,
-            # data
-            'points': [],
-            'num_points': 0,
-            't_int': None, # interpolated timestamps
-            'v_int': None, # interpolated values
-            'v_enc': None, # encoded values
         }
         for (id, param) in parameters.items()
     }
@@ -158,8 +157,8 @@ def parse(bytes, parameters):
     print('sorting data... ', end='', flush=True)
     start = time.time()
     for ch in channels.values():
+        ch['n_points'] = len(ch['points'])
         # sort points by timestamp
-        ch['num_points'] = len(ch['points'])
         ch['points'].sort(key=lambda pt: pt[0])
         ch['points'] = np.array(ch['points'], dtype=np.float64)
         # timestamps = ch['points'][:,0]
@@ -177,62 +176,41 @@ def parse(bytes, parameters):
     for ch in channels.values():
         # calculate time axis delta / channel frequency
         delta = 100 # assume 100ms if a channel has a single point
-        if len(ch['points']) > 1:
+        if ch['n_points'] > 1:
             # find the most common time delta between points
             deltas = np.diff(ch['points'][:,0])
             unique_deltas, counts = np.unique(deltas, return_counts=True)
-            delta = min(int(unique_deltas[counts == counts.max()][0]), 100)
+            delta = min(int(unique_deltas[counts == counts.max()][0]), 100) # max delta = 100ms
             # round so that delta & frequency are integers
             while 1000 % delta != 0: delta += 1
-        # use this delta to get channel frequency (between 1Hz and 1000Hz)
+        # use this delta to get channel frequency
         ch['delta_ms'] = delta
-        ch['frequency_hz'] = math.trunc(max(1, min(1000, 1000 / ch['delta_ms'])))
+        ch['frequency_hz'] = math.trunc(1000 / ch['delta_ms'])
         ch['sample_count'] = math.trunc(ch['t_max'] / ch['delta_ms'])
-
-        # print()
         # create a new time axis with this frequency and sample count
-        t_int = list(range(ch['sample_count'])) * ch['delta_ms']
-        # get closest point to each time tick
-        v_int = [0] * ch['sample_count']
-        i = 0
-        j = 0
-        ts = 0
-        while j < ch['sample_count']:
-            if ch['points'][i][0] == ch['points'][0][0]:
-                if ts > ch['points'][i][0]:
-                    i += 1
-                else:
-                    v_int[j] = ch['points'][i][1]
-                    j += 1
-                    ts += ch['delta_ms']
-            else:
-                while ts > ch['points'][i+1][0]: i += 1
-                v_int[j] = ch['points'][i][1]
-                j += 1
-                ts += ch['delta_ms']
-
-        ch['t_int'] = np.array(t_int, dtype=np.float64)
-        ch['v_int'] = np.array(v_int, dtype=np.float64)
+        ch['t_int'] = np.arange(0, ch['delta_ms'] * ch['sample_count'], ch['delta_ms'])
+        # interpolate data over the new time axis
+        ch['v_int'] = np.interp(ch['t_int'], ch['points'][:,0], ch['points'][:,1])
     elapsed = round(time.time() - start, 2)
     print(f'({elapsed}s)')
 
     print('encoding channels... ', end='', flush=True)
     start = time.time()
-    for ch in channels.values():
-        ch['v_enc'] = []
-        ch['shift'], ch['scalar'], ch['divisor'], ch['scf'] = get_scalars(ch['id'], ch['v_min'], ch['v_max'])
-        if ch['divisor'] > 0:
+    for id in list(channels.keys()):
+        ch = channels[id]
+        try:
+            ch['shift'], ch['scalar'], ch['divisor'] = get_scalars(ch['v_min'], ch['v_max'])
+        except:
+            # encoding failed, remove channel
+            del channels[id]
+            print(f'failed to encode channel {id} min={ch['v_min']} max={ch['v_max']}')
+        else:
             ch['v_enc'] = np.array(
                 [v / 10**-ch['shift'] / ch['scalar'] * ch['divisor'] for v in ch['v_int']],
                 dtype=np.int32
             )
     elapsed = round(time.time() - start, 2)
     print(f'({elapsed}s)')
-
-    for id in list(channels.keys()):
-        # remove channels with failed encodings
-        if len(channels[id]['v_enc']) == 0:
-            del channels[id]
 
     print(f'created {len(channels)} channels')
     return channels

--- a/gdat.py
+++ b/gdat.py
@@ -68,6 +68,7 @@ def decode_packets(bytes, channels, parameters):
             esc = False
         else:
             packet.append(b)
+    decode()
         
     return (packets, errors)
 
@@ -75,43 +76,45 @@ def decode_packets(bytes, channels, parameters):
 # value = encoded_value * 10^-shift * scalar / divisor
 # encoded_value = value / 10^-shift / scalar * divisor
 # to make the most of a s16: abs_max = (2^15 - 1) * 10^-shift * scalar / divisor
-def get_scalars(abs_max):
-    if abs_max == 0:
-        shift = 0
-        scalar = 1
-        divisor = 1
-        return (shift, scalar, divisor)
+def get_scalars(id, v_min, v_max):
+    abs_max = max(abs(v_min), abs(v_max))
 
-    # start with high shift to preserve precision
-    for shift in range(10, -10, -1):
-        # calculate required scale to use this shift
-        scale = abs_max / (2**15-1) / 10**-shift
-        # convert scale to integer fraction
-        scalar, divisor = Fraction(scale).limit_denominator(2**15-1).as_integer_ratio()
-        if scalar == 0:
-            # scale can't be represented
-            continue
-        elif -2**15 <= scalar <= 2**15-1:
-            # both scalar & divisor will fit in s16
-            break
+    exp = 0
+    scale = abs_max
+    scf = 0
+    shift = 0
+    offset = 0
+    done = False
+
+    if v_max - v_min <= 0.001:
+        if -0.0001 <= abs_max <= 0.0001:
+            exp = 0
+            scale = 1
         else:
-            # adjust scalar to fit in s16 (adjust divisor to maintain fraction)
-            adj = (2**15-1) / scalar
-            scalar = round(scalar * adj)
-            divisor = round(divisor * adj)
-            # check if divisor is still valid
-            if -2**15 <= divisor <= 2**15-1 and divisor != 0:
-                # max encoded value
-                enc_max = abs_max / 10**-shift / scalar * divisor
-                # % error with this new fraction to the ideal scale
-                error = ((scalar / divisor) - scale) / scale
-                # 10% error is acceptable
-                if enc_max <= 2**15-1 and error <= 0.1:
-                    break
-    else:
-        raise Exception(f'failed to find scalars for ({abs_max})')
+            exp = 1
+            scale = abs_max
+        scf = 8 * (10**exp) / scale
+        shift = 6 - exp
+        done = True
 
-    return (shift, scalar, divisor)
+    exp = -37
+    while exp < 37 and not done:
+        if scale >= 8 * 10**exp and scale < 8 * 10**(exp+1):
+            scf = 8 * 10**exp / scale
+            shift = 6 - exp
+            done = True
+        exp += 1
+
+    if not done:
+        print(f'failed to find scalars for ch={id} min={v_min} max={v_max}')
+    
+    scalar, divisor = Fraction(scf).limit_denominator(2047).as_integer_ratio()
+    if scalar > 2047:
+        scalar = 0
+        divisor = 0
+        shift = 0
+    
+    return (shift, scalar, divisor, scf)
 
 def parse(bytes, parameters):
     channels = {
@@ -133,6 +136,7 @@ def parse(bytes, parameters):
             'offset': 0,
             # data
             'points': [],
+            'num_points': 0,
             't_int': None, # interpolated timestamps
             'v_int': None, # interpolated values
             'v_enc': None, # encoded values
@@ -142,7 +146,7 @@ def parse(bytes, parameters):
 
     print('decoding packets... ', end='', flush=True)
     start = time.time()
-    (packets, errors) = decode_packets(bytes, channels, parameters)
+    packets, errors = decode_packets(bytes, channels, parameters)
     for id in list(channels.keys()):
         # remove channels with no data
         if len(channels[id]['points']) == 0:
@@ -155,6 +159,7 @@ def parse(bytes, parameters):
     start = time.time()
     for ch in channels.values():
         # sort points by timestamp
+        ch['num_points'] = len(ch['points'])
         ch['points'].sort(key=lambda pt: pt[0])
         ch['points'] = np.array(ch['points'], dtype=np.float64)
         # timestamps = ch['points'][:,0]
@@ -176,16 +181,13 @@ def parse(bytes, parameters):
             # find the most common time delta between points
             deltas = np.diff(ch['points'][:,0])
             unique_deltas, counts = np.unique(deltas, return_counts=True)
-            delta = int(unique_deltas[counts == counts.max()][0])
+            delta = min(int(unique_deltas[counts == counts.max()][0]), 100)
             # round so that delta & frequency are integers
             while 1000 % delta != 0: delta += 1
         # use this delta to get channel frequency (between 1Hz and 1000Hz)
         ch['delta_ms'] = delta
         ch['frequency_hz'] = math.trunc(max(1, min(1000, 1000 / ch['delta_ms'])))
         ch['sample_count'] = math.trunc(ch['t_max'] / ch['delta_ms'])
-
-        # interpolate points from t=0 to t=last
-        # ch['v_int'] = np.interp(ch['t_int'], ch['points'][:,0], ch['points'][:,1])
 
         # print()
         # create a new time axis with this frequency and sample count
@@ -201,13 +203,11 @@ def parse(bytes, parameters):
                     i += 1
                 else:
                     v_int[j] = ch['points'][i][1]
-                    # print(ts, ch['points'][i][0], ch['points'][i][1])
                     j += 1
                     ts += ch['delta_ms']
             else:
                 while ts > ch['points'][i+1][0]: i += 1
                 v_int[j] = ch['points'][i][1]
-                # print(ts, ch['points'][i][0], ch['points'][i][1])
                 j += 1
                 ts += ch['delta_ms']
 
@@ -219,22 +219,20 @@ def parse(bytes, parameters):
     print('encoding channels... ', end='', flush=True)
     start = time.time()
     for ch in channels.values():
-        if ch['v_int'] is None or len(ch['v_int']) == 0:
-            ch['v_enc'] = []
-        else:
-            abs_max = max(ch['v_int'].max(), ch['v_int'].min(), key=abs)
-            try:
-                ch['shift'], ch['scalar'], ch['divisor'] = get_scalars(abs_max)
-            except:
-                print(f"failed to encode channel \"{ch['name']}\" ({ch['id']}) abs_max: {abs_max}")
-                ch['v_enc'] = []
-            else:
-                ch['v_enc'] = np.array(
-                    [v / 10**-ch['shift'] / ch['scalar'] * ch['divisor'] for v in ch['v_int']],
-                    dtype=np.int16
-                )
+        ch['v_enc'] = []
+        ch['shift'], ch['scalar'], ch['divisor'], ch['scf'] = get_scalars(ch['id'], ch['v_min'], ch['v_max'])
+        if ch['divisor'] > 0:
+            ch['v_enc'] = np.array(
+                [v / 10**-ch['shift'] / ch['scalar'] * ch['divisor'] for v in ch['v_int']],
+                dtype=np.int32
+            )
     elapsed = round(time.time() - start, 2)
     print(f'({elapsed}s)')
+
+    for id in list(channels.keys()):
+        # remove channels with failed encodings
+        if len(channels[id]['v_enc']) == 0:
+            del channels[id]
 
     print(f'created {len(channels)} channels')
     return channels

--- a/go4v.py
+++ b/go4v.py
@@ -120,7 +120,6 @@ def info_gdat():
         for channel in gdat_channels.values():
             # exclude a few keys from the table
             ch = {k:v for k,v in channel.items() if k not in ['points', 't_int', 'v_int', 'v_enc']}
-            ch['points'] = len(channel['points'])
             ch_info.append(ch)
         print(tabulate(ch_info, headers='keys'))
     else:
@@ -141,19 +140,10 @@ def info_ld():
         print(tabulate(ld_metadata['weather'].items()))
         print('CHANNELS')
         ch_info = []
-        for ch in ld_channels.values():
-            ch_info.append({
-                'meta_ptr': hex(ch['meta_ptr']),
-                'data_ptr': hex(ch['data_ptr']),
-                'size': ch['size'],
-                'name': ch['name'],
-                'sample_rate': ch['sample_rate'],
-                'sample_count': ch['sample_count'],
-                'shift': ch['shift'],
-                'scalar': ch['scalar'],
-                'divisor': ch['divisor'],
-                'offset': ch['offset'],
-            })
+        for channel in ld_channels.values():
+            # exclude a few keys from the table
+            ch = {k:v for k,v in channel.items() if k not in ['data']}
+            ch_info.append(ch)
         print(tabulate(ch_info, headers='keys'))
     else:
         print('no .ld loaded')

--- a/ld.py
+++ b/ld.py
@@ -23,20 +23,22 @@ formats = {}
 layouts['header'] = (
 ###  KEY                FORMAT     OFFSET (h)  LENGTH (h)
     ('',                '<'),      #
-    ('sof',             'Q'),      # 0         8
+    ('sof',             'Q'),      # 0         8         0x40
     ('meta_ptr',        'I'),      # 8         4
     ('data_ptr',        'I'),      # C         4
     ('',                '20x'),    # 10        14
     ('event_ptr',       'I'),      # 24        4
-    ('',                '28x'),    # 28        1C
-    ('magic1',          'H'),      # 44        2         15
-    ('device_serial',   'I'),      # 46        4
-    ('device_type',     '8s'),     # 4A        8
-    ('device_version',  'H'),      # 52        2         scale: 100
-    ('magic2',          'H'),      # 54        2         128
+    ('',                '24x'),    # 28        18
+    ('magic1',          'H'),      # 40        2         0x0002
+    ('magic2',          'H'),      # 42        2         0x4240
+    ('magic3',          'H'),      # 44        2         0x000F
+    ('device_serial',   'I'),      # 46        4         21115
+    ('device_type',     '8s'),     # 4A        8         ADL
+    ('device_version',  'H'),      # 52        2         560
+    ('magic4',          'H'),      # 54        2         0x0080
     ('num_channels',    'H'),      # 56        2
     ('num_channels2',   'H'),      # 58        2
-    ('magic3',          'I'),      # 5A        4         66036
+    ('magic5',          'I'),      # 5A        4         0x000A01F4
     ('date',            '32s'),    # 5E        20
     ('time',            '32s'),    # 7E        20
     ('driver',          '64s'),    # 9E        40
@@ -44,12 +46,15 @@ layouts['header'] = (
     ('engine_id',       '64s'),    # 11E       40
     ('venue',           '64s'),    # 15E       40
     ('',                '1088x'),  # 19E       440
-    ('magic4',          'I'),      # 5DE       4         45126145
+    ('magic6',          'I'),      # 5DE       4         0x02B09201
     ('',                '2x'),     # 5E2       2
     ('session',         '64s'),    # 5E4       40
     ('short_comment',   '64s'),    # 624       40
-    ('',                '48x'),    # 664       30
-    ('team',            '64s'),    # 694       40
+    ('',                '8x'),     # 664       8
+    ('magic7',          'H'),      # 66C       2         0x0045
+    ('',                '38x'),    # 66E       26
+    ('team',            '32s'),    # 694       20
+    ('',                '46x'),    # 6B4       2E
 )
 
 (k, f) = zip(*layouts['header'])
@@ -60,11 +65,12 @@ formats['header'] = ''.join(f)
 layouts['event'] = (
 ###  KEY              FORMAT     OFFSET (h)  LENGTH (h)
     ('',              '<'),      #
-    ('event',         '64s'),    # 6D4       40
-    ('session',       '64s'),    # 714       40
-    ('long_comment',  '1024s'),  # 754       400
-    ('venue_ptr',     'I'),      # B54       4
-    ('weather_ptr',   'I'),      # B58       4
+    ('event',         '64s'),    # 6E2       40
+    ('session',       '64s'),    # 722       40
+    ('long_comment',  '1024s'),  # 762       400
+    ('venue_ptr',     'I'),      # B62       4
+    ('weather_ptr',   'I'),      # B66       4
+    ('',              '1996x'),  # B6A       7CC
 )
 
 (k, f) = zip(*layouts['event'])
@@ -75,13 +81,13 @@ formats['event'] = ''.join(f)
 layouts['venue'] = (
 ###  KEY                FORMAT     OFFSET (h)  LENGTH (h)
     ('',                '<'),      #
-    ('venue',           '64s'),    # B5C       40
-    ('',                '2x'),     # B9C       2
-    ('venue_length',    'I'),      # B9E       4         unit: mm
-    ('',                '1028x'),  # BA2       404
-    ('vehicle_ptr',     'I'),      # FA6       4
-    ('venue_category',  '1024s'),  # FAA       400    
-    ('',                '976x')    # 13AA      3D0
+    ('venue',           '64s'),    # 1336      40
+    ('',                '2x'),     # 1376      2
+    ('venue_length',    'I'),      # 1378      4         unit: mm
+    ('',                '1028x'),  # 137C      404
+    ('vehicle_ptr',     'I'),      # 1780      4
+    ('venue_category',  '32s'),    # 1784      20
+    ('',                '1968x')   # 17A4      7B0
 )
 
 (k, f) = zip(*layouts['venue'])
@@ -92,28 +98,30 @@ formats['venue'] = ''.join(f)
 layouts['vehicle'] = (
 ###  KEY                   FORMAT     OFFSET (h)  LENGTH (h)
     ('',                   '<'),      #
-    ('vehicle_id',         '64s'),    # 177A      40
-    ('vehicle_desc',       '64s'),    # 17BA      40
-    ('engine_id',          '64s'),    # 17FA      40
-    ('vehicle_weight',     'H'),      # 183A      2         unit: kg
-    ('fuel_tank',          'H'),      # 183C      2         unit: deciliter
-    ('vehicle_type',       '32s'),    # 183E      20
-    ('driver_type',        '32s'),    # 185E      20
-    ('diff_ratio',         'H'),      # 187E      2         scale: 1000
-    ('gear1',              'H'),      # 1880      2         scale: 1000
-    ('gear2',              'H'),      # 1882      2         scale: 1000
-    ('gear3',              'H'),      # 1884      2         scale: 1000
-    ('gear4',              'H'),      # 1886      2         scale: 1000
-    ('gear5',              'H'),      # 1888      2         scale: 1000
-    ('gear6',              'H'),      # 188A      2         scale: 1000
-    ('gear7',              'H'),      # 188C      2         scale: 1000
-    ('gear8',              'H'),      # 188E      2         scale: 1000
-    ('gear9',              'H'),      # 1890      2         scale: 1000
-    ('gear10',             'H'),      # 1892      2         scale: 1000
-    ('vehicle_track',      'H'),      # 1894      2         unit: mm
-    ('vehicle_wheelbase',  'I'),      # 1896      4         unit: mm
-    ('vehicle_comment',    '1028s'),  # 189A      404
-    ('vehicle_number',     '64s'),    # 1C9E      40
+    ('vehicle_id',         '64s'),    # 1F54      40
+    ('vehicle_desc',       '64s'),    # 1F94      40
+    ('engine_id',          '64s'),    # 1FD4      40
+    ('vehicle_weight',     'H'),      # 2014      2         unit: kg
+    ('fuel_tank',          'H'),      # 2016      2         unit: deciliter
+    ('vehicle_type',       '32s'),    # 2018      20
+    ('driver_type',        '32s'),    # 2038      20
+    ('diff_ratio',         'H'),      # 2058      2
+    ('gear1',              'H'),      # 205A      2
+    ('gear2',              'H'),      # 205C      2
+    ('gear3',              'H'),      # 205E      2
+    ('gear4',              'H'),      # 2060      2
+    ('gear5',              'H'),      # 2062      2
+    ('gear6',              'H'),      # 2064      2
+    ('gear7',              'H'),      # 2066      2
+    ('gear8',              'H'),      # 2068      2
+    ('gear9',              'H'),      # 206A      2
+    ('gear10',             'H'),      # 206C      2
+    ('vehicle_track',      'H'),      # 206E      2         unit: mm
+    ('vehicle_wheelbase',  'I'),      # 2070      4         unit: mm
+    ('vehicle_comment',    '1024s'),  # 2074      400
+    ('',                   '4x'),     # 2474      4
+    ('vehicle_number',     '32s'),    # 2478      20
+    ('',                   '1968x'),  # 2498      7B0
 )
 
 (k, f) = zip(*layouts['vehicle'])
@@ -124,19 +132,20 @@ formats['vehicle'] = ''.join(f)
 layouts['weather'] = (
 ###  KEY                 FORMAT     OFFSET (h)  LENGTH (h)
     ('',                 '<'),      #
-    ('sky',              '64s'),    # 1CDE       40
-    ('air_temp',         '16s'),    # 1D1E       10
-    ('air_temp_unit',    '8s'),     # 1D2E       8
-    ('track_temp',       '16s'),    # 1D36       10
-    ('track_temp_unit',  '8s'),     # 1D46       8
-    ('pressure',         '16s'),    # 1D4E       10
-    ('pressure_unit',    '8s'),     # 1D5E       8
-    ('humidity',         '16s'),    # 1D66       10
-    ('humidity_unit',    '8s'),     # 1D76       8
-    ('wind_speed',       '16s'),    # 1D7E       10
-    ('wind_speed_unit',  '8s'),     # 1D8E       8
-    ('wind_direction',   '64s'),    # 1D96       40
-    ('weather_comment',  '1024s'),  # 1DD6       400
+    ('sky',              '64s'),    # 2C48       40
+    ('air_temp',         '16s'),    # 2C88       10
+    ('air_temp_unit',    '8s'),     # 2C98       8
+    ('track_temp',       '16s'),    # 2CA0       10
+    ('track_temp_unit',  '8s'),     # 2CB0       8
+    ('pressure',         '16s'),    # 2CB8       10
+    ('pressure_unit',    '8s'),     # 2CC8       8
+    ('humidity',         '16s'),    # 2CD0       10
+    ('humidity_unit',    '8s'),     # 2CE0       8
+    ('wind_speed',       '16s'),    # 2CE8       10
+    ('wind_speed_unit',  '8s'),     # 2CF8       8
+    ('wind_direction',   '64s'),    # 2D00       40
+    ('weather_comment',  '1024s'),  # 2D40       400
+    ('',                 '776x'),   # 3140       308
 )
 
 (k, f) = zip(*layouts['weather'])
@@ -147,6 +156,7 @@ formats['weather'] = ''.join(f)
 # value = encoded_value * 10^-shift * scalar / divisor
 # encoded_value = value / 10^-shift / scalar * divisor
 # offset wrt meta ptr
+# first meta_ptr at 0x3448
 layouts['ch_meta'] = (
 ###  KEY                 FORMAT     OFFSET (h)  LENGTH (h)
     ('',                 '<'),      #
@@ -154,8 +164,8 @@ layouts['ch_meta'] = (
     ('next_ptr',         'I'),      # 4         4
     ('data_ptr',         'I'),      # 8         4
     ('sample_count',     'I'),      # C         4
-    ('magic1',           'I'),      # 10        4         196609
-    ('size',             'H'),      # 14        2         2: s16 4: s32
+    ('magic1',           'I'),      # 10        4         s16: 0x00030001, s32: 0x0005AA55
+    ('size',             'H'),      # 14        2         s16: 0x02 s32: 0x04
     ('sample_rate',      'H'),      # 16        2
     ('offset',           'h'),      # 18        2
     ('scalar',           'h'),      # 1A        2
@@ -187,26 +197,38 @@ def unpack(file, offset, keys, format):
     return {k:v for k,v in zip(keys, values) if k != ''}
 
 def parse(path):
-    metadata = {}
+    metadata = {
+        'header': {},
+        'event': {},
+        'venue': {},
+        'vehicle': {},
+        'weather': {},
+        'meta_ptr': {}
+    }
     channels = {}
     f = open(path, 'rb')
 
-    metadata['header'] = unpack(f, 0, keys['header'], formats['header'])
+    try: metadata['header'] = unpack(f, 0, keys['header'], formats['header'])
+    except: print('failed to unpack header')
 
     if metadata['header']['event_ptr'] > 0:
-        metadata['event'] = unpack(f, metadata['header']['event_ptr'], keys['event'], formats['event'])
+        try: metadata['event'] = unpack(f, metadata['header']['event_ptr'], keys['event'], formats['event'])
+        except: print('failed to unpack event')
     else: print('no event_ptr')
 
     if metadata['event']['venue_ptr'] > 0:
-        metadata['venue'] = unpack(f, metadata['event']['venue_ptr'], keys['venue'], formats['venue'])
+        try: metadata['venue'] = unpack(f, metadata['event']['venue_ptr'], keys['venue'], formats['venue'])
+        except: print('failed to unpack venue')
     else: print('no venue_ptr')
 
     if metadata['venue']['vehicle_ptr'] > 0:
-        metadata['vehicle'] = unpack(f, metadata['venue']['vehicle_ptr'], keys['vehicle'], formats['vehicle'])
+        try: metadata['vehicle'] = unpack(f, metadata['venue']['vehicle_ptr'], keys['vehicle'], formats['vehicle'])
+        except: print('failed to unpack vehicle')
     else: print('no vehicle_ptr')
 
     if metadata['event']['weather_ptr'] > 0:
-        metadata['weather'] = unpack(f, metadata['event']['weather_ptr'], keys['weather'], formats['weather'])
+        try: metadata['weather'] = unpack(f, metadata['event']['weather_ptr'], keys['weather'], formats['weather'])
+        except: print('failed to unpack weather')
     else: print('no weather_ptr')
 
     if metadata['header']['meta_ptr'] > 0:
@@ -243,7 +265,6 @@ def parse(path):
         if len(channels) != metadata['header']['num_channels']:
             print(f"WARNING: num_channels ({metadata['header']['num_channels']})",
                   f"does not match number of channels found ({len(channels)})\n")
-            
     else: print('no meta_pr')
 
     f.close()
@@ -275,27 +296,30 @@ def write(path, channels, t0):
 
     # order must match formats['header']
     header_values = {
-        'sof': 7567732375616,
+        'sof': 0x40,
         'meta_ptr': meta_offset,
         'data_ptr': data_offset,
         'event_ptr': event_offset,
-        'magic1': 15,
+        'magic1': 0x0002,
+        'magic2': 0x4240,
+        'magic3': 0x000F,
         'device_serial': 21115,
         'device_type': 'ADL',
         'device_version': 560,
-        'magic2': 128,
+        'magic4': 0x0080,
         'num_channels': len(channels),
         'num_channels2': len(channels),
-        'magic3': 66036,
+        'magic5': 0x000A01F4,
         'date': time.strftime('%d/%m/%Y', t0),
         'time': time.strftime('%H:%M:%S', t0),
         'driver': 'Driver',
         'vehicle_id': 'VehicleID',
         'engine_id': '',
         'venue': 'Venue',
-        'magic4': 45126145,
+        'magic6': 0x02B09201,
         'session': 'Session',
         'short_comment': 'Comment',
+        'magic7': 0x0045,
         'team': ''
     }
 
@@ -344,7 +368,7 @@ def write(path, channels, t0):
 
     # order must match formats['weather']
     weather_values = {
-        'sky': '',
+        'sky': 'Sunny',
         'air_temp': '',
         'air_temp_unit': '',
         'track_temp': '',
@@ -379,27 +403,27 @@ def write(path, channels, t0):
         ch_meta = {
             'prev_ptr': 0,
             'next_ptr': 0,
-            'data_ptr': 0,
+            'data_ptr': data_offset + data_size,
             'sample_count': len(ch['v_enc']),
-            'magic1': 196609,
-            'size': 2,
-            'sample_rate': ch['sample_rate'],
+            'magic1': 0x0005AA55,
+            'size': 0x04,
+            'sample_rate': ch['frequency_hz'],
             'offset': ch['offset'],
             'scalar': ch['scalar'],
             'divisor': ch['divisor'],
             'shift': ch['shift'],
             'name': ch['name'],
-            'short_name': '',
-            'unit': ch['unit'],
+            'short_name': ch['unit'],
+            'unit': '',
         }
-        ch_meta['data_ptr'] = data_offset + data_size
-        data_size += ch_meta['sample_count'] * ch_meta['size']
 
-        if i == 0: ch_meta['prev_ptr'] = 0
+        if i == 0: ch_meta['prev_ptr'] = 0 # first channel has no prev_ptr
         else: ch_meta['prev_ptr'] = meta_offset + ch_meta_size * (i - 1)
 
-        if i == len(channels) - 1: ch_meta['next_ptr'] = 0
+        if i == len(channels) - 1: ch_meta['next_ptr'] = 0 # last channel has no next_ptr
         else: ch_meta['next_ptr'] = meta_offset + ch_meta_size * (i + 1)
+
+        data_size += ch_meta['sample_count'] * ch_meta['size']
 
         try:
             channel_metadata += struct.pack(formats['ch_meta'], *enc_str(ch_meta.values()))
@@ -414,8 +438,10 @@ def write(path, channels, t0):
         # pack data for each channel
         # do this at write time to avoid storing large byte strings in memory
         for ch in channels.values():
+            # assumes data has been encoded for a s32
+            data = struct.pack(f"<{len(ch['v_enc'])}i", *ch['v_enc'])
             # assumes data has been encoded for a s16
-            data = struct.pack(f"<{len(ch['v_enc'])}h", *ch['v_enc'])
+            # data = struct.pack(f"<{len(ch['v_enc'])}h", *ch['v_enc'])
             f.write(data)
     elapsed = round(time.time() - start, 2)
     print(f'({elapsed}s)')

--- a/ld.py
+++ b/ld.py
@@ -174,7 +174,7 @@ layouts['ch_meta'] = (
     ('name',             '32s'),    # 20        20
     ('short_name',       '8s'),     # 40        8
     ('unit',             '12s'),    # 48        C
-    ('',                 '40x'),    # 54        28
+    ('',                 '40x'),    # 54        28        sometimes contains nonzero values
 )
 
 (k, f) = zip(*layouts['ch_meta'])
@@ -300,7 +300,7 @@ def write(path, channels, t0):
         'meta_ptr': meta_offset,
         'data_ptr': data_offset,
         'event_ptr': event_offset,
-        'magic1': 0x0002,
+        'magic1': 0,
         'magic2': 0x4240,
         'magic3': 0x000F,
         'device_serial': 21115,
@@ -309,7 +309,7 @@ def write(path, channels, t0):
         'magic4': 0x0080,
         'num_channels': len(channels),
         'num_channels2': len(channels),
-        'magic5': 0x000A01F4,
+        'magic5': 327700,
         'date': time.strftime('%d/%m/%Y', t0),
         'time': time.strftime('%H:%M:%S', t0),
         'driver': 'Driver',
@@ -413,8 +413,8 @@ def write(path, channels, t0):
             'divisor': ch['divisor'],
             'shift': ch['shift'],
             'name': ch['name'],
-            'short_name': ch['unit'],
-            'unit': '',
+            'short_name': '',
+            'unit': ch['unit'],
         }
 
         if i == 0: ch_meta['prev_ptr'] = 0 # first channel has no prev_ptr


### PR DESCRIPTION
fixes #2 

GopherVision data is now aligned with the DLM parser (GV in orange, DLM in white but can't really see because they're aligned).
![image](https://github.com/gopher-motorsports/gopher-vision/assets/69396515/54d2d524-5b8b-4a34-92f2-0571e8ce050f)

This issue was likely solved by two changes in combination:
- Channel frequency is now determined in the same way as the DLM parser (by using the most common time delta between datapoints).
- Fixed some magic numbers in the .ld file that were likely breaking the sample rate shown in i2's channel details

Additionally:
- Values are encoded in s32 instead of s16.
- Now using the same algorithm to find scalars that the DLM uses (except for the float to fraction conversion). This can likely be improved in the future.
- GopherVision uses NumPy's linear interpolation to fit data to an evenly spaced time axis rather than snapping points to the nearest timestamp like the DLM parser does. This produces some minor differences in data. The DLM parser produces square waves while GopherVision has smoother interpolated curves.

![image](https://github.com/gopher-motorsports/gopher-vision/assets/69396515/9070da44-c54b-4801-954b-d541b0d7358b)
![image](https://github.com/gopher-motorsports/gopher-vision/assets/69396515/74842777-5b06-41d3-9e92-dc16d7f2fc45)