### PR TITLE
Added presets dropdown

### DIFF
--- a/db.py
+++ b/db.py
@@ -1,8 +1,6 @@
 import os
 from supabase import create_client, Client
 
-# supabase project password: Go4-Visi@n!
-
 url = 'https://dfdnzxmtohnlzrtyigcw.supabase.co' 
 key = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRmZG56eG10b2hubHpydHlpZ2N3Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3Mjk2NTIzNzUsImV4cCI6MjA0NTIyODM3NX0.1J0HBm00c76dWTrJZP-q34d24ToB5uq1i1BYtvbBPak'
 supabase: Client = create_client(url, key)

--- a/db.py
+++ b/db.py
@@ -1,0 +1,34 @@
+import os
+from supabase import create_client, Client
+
+# supabase project password: Go4-Visi@n!
+
+url = 'https://dfdnzxmtohnlzrtyigcw.supabase.co' 
+key = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRmZG56eG10b2hubHpydHlpZ2N3Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3Mjk2NTIzNzUsImV4cCI6MjA0NTIyODM3NX0.1J0HBm00c76dWTrJZP-q34d24ToB5uq1i1BYtvbBPak'
+supabase: Client = create_client(url, key)
+
+# creates a preset in the database
+def upload_preset(preset_name, id_lst, pname_lst, ymin_lst, ymax_lst):
+  supabase.table("presets").insert({
+  "preset_name": preset_name,
+  "id": id_lst,
+  "param_name": pname_lst,
+  "y_min": ymin_lst,
+  "y_max": ymax_lst
+}).execute()
+
+# returns a list of existing presets in the database
+def get_preset_names():
+  names = supabase.table("presets").select("preset_name").execute().data
+  values_list = [item['preset_name'] for item in names]
+  return values_list
+
+# returns data of requested preset
+def get_preset_info(preset_name):
+  preset_info = supabase.table("presets").select().eq("preset_name", preset_name).execute().data
+  return preset_info
+
+
+
+
+

--- a/gui.py
+++ b/gui.py
@@ -185,39 +185,38 @@ def save_preset():
 # creates new preset and upload to db
 def upload_preset(sender):
 
-    plots = []
-    pids = [int(alias[7:]) for alias in dpg.get_aliases() if 'p_plot_' in alias]
-    # find currently visible plots
-    for pid in pids:
-        if dpg.is_item_visible(f'p_plot_{pid}'):
-            y_axis = dpg.get_axis_limits(f'{pid}_y')
-            plots.append({
-                'id': pid,
-                'name': parameters[pid]['name'],
-                'y_min': y_axis[0],
-                'y_max': y_axis[1],
-                'v_pos': dpg.get_item_pos(f'p_plot_{pid}')[1]
-            })
-    # sort by vertical position
-    plots.sort(key=lambda p: p['v_pos'])
-    print(plots)
-
-
+    # plots = []
     # pids = [int(alias[7:]) for alias in dpg.get_aliases() if 'p_plot_' in alias]
-    # pnames = []
-    # py_mins = []
-    # py_maxes = []
-    # new_preset_name = dpg.get_value("name_input")
     # # find currently visible plots
     # for pid in pids:
     #     # if dpg.is_item_visible(f'p_plot_{pid}'):
     #     y_axis = dpg.get_axis_limits(f'{pid}_y')
-    #     pnames.append(parameters[pid]['name'])
-    #     py_mins.append(y_axis[0])
-    #     py_maxes.append(y_axis[1])
-    # db.upload_preset(new_preset_name,pids,pnames,py_mins,py_maxes)
-    # dpg.add_selectable(parent='presets_list', label=new_preset_name, filter_key=new_preset_name, callback=load_preset, user_data=new_preset_name)
-    # dpg.delete_item("get_preset_name_window")
+    #     plots.append({
+    #         'id': pid,
+    #         'name': parameters[pid]['name'],
+    #         'y_min': y_axis[0],
+    #         'y_max': y_axis[1],
+    #         'v_pos': dpg.get_item_pos(f'p_plot_{pid}')[1]
+    #     })
+    # # sort by vertical position
+    # plots.sort(key=lambda p: p['v_pos'])
+    # print(plots)
+
+    pids = [int(alias[7:]) for alias in dpg.get_aliases() if 'p_plot_' in alias]
+    pnames = []
+    py_mins = []
+    py_maxes = []
+    new_preset_name = dpg.get_value("name_input")
+    # find currently visible plots
+    for pid in pids:
+        # if dpg.is_item_visible(f'p_plot_{pid}'):
+        y_axis = dpg.get_axis_limits(f'{pid}_y')
+        pnames.append(parameters[pid]['name'])
+        py_mins.append(y_axis[0])
+        py_maxes.append(y_axis[1])
+    db.upload_preset(new_preset_name,pids,pnames,py_mins,py_maxes)
+    dpg.add_selectable(parent='presets_list', label=new_preset_name, filter_key=new_preset_name, callback=load_preset, user_data=new_preset_name)
+    dpg.delete_item("get_preset_name_window")
 
 def start_recording(sender, _):
     global node


### PR DESCRIPTION
Added presets dropdown menu using a database, kept original csv functionality just in case. Currently no option in GUI to delete created presets in the DB, will work on that. 

Also found issue with original CSV presets where only plots visible on the screen are saved as presets, currently haven't found a solution, so I implemented a workaround and defaulted y-axis limits to -0.5 and 0.5 if plot is invisible. Now presets will save every opened plot, except axis limits on invisible graphs will be a default value.